### PR TITLE
fix: use pip docker package v6

### DIFF
--- a/tasks/docker-environment.yml
+++ b/tasks/docker-environment.yml
@@ -60,6 +60,7 @@
     name:
       - docker<7
       - docker-compose
+      - websocket
 
 - name: "DOCKER - Log into docker registry"
   docker_login:

--- a/tasks/docker-environment.yml
+++ b/tasks/docker-environment.yml
@@ -46,13 +46,20 @@
   apt:
     name:
       - containerd.io
-      - python3-docker
       - pass
     state: present
 
-- name: "DOCKER - Install docker-compose"
+- name: "uninstall python3-docker from apt"
+  apt:
+    name:
+      - python3-docker
+    state: absent
+
+- name: "DOCKER - Install pip packages docker and docker-compose"
   pip:
-    name: docker-compose
+    name:
+      - docker<7
+      - docker-compose
 
 - name: "DOCKER - Log into docker registry"
   docker_login:


### PR DESCRIPTION
v7 is not compatible with docker-compose v1
(which is used by ansible tasks)